### PR TITLE
Adjustment of some glyphs for Santali

### DIFF
--- a/sources/NotoSansDevanagari.glyphspackage/fontinfo.plist
+++ b/sources/NotoSansDevanagari.glyphspackage/fontinfo.plist
@@ -4841,7 +4841,7 @@ language SAN ;
 	lookup blwf_rakar_forms_SAN;
 
 language SAT;
-    sub [a-deva aa-deva] nukta-deva' by nukta-deva.sat;
+    sub [aa-deva o-deva au-deva aaMatra-deva oMatra-deva auMatra-deva] nukta-deva' by nukta-deva.sat;
 
 #//////////////////////////////////////////////////////////////////////////////////
 ";

--- a/sources/NotoSansDevanagari.glyphspackage/glyphs/a-deva.glyph
+++ b/sources/NotoSansDevanagari.glyphspackage/glyphs/a-deva.glyph
@@ -19,10 +19,6 @@ name = nukta;
 pos = (254,-31);
 },
 {
-name = nukta.sat;
-pos = (557,-135);
-},
-{
 name = top;
 pos = (544,622);
 }
@@ -133,10 +129,6 @@ pos = (634,622);
 {
 name = nukta;
 pos = (282,-40);
-},
-{
-name = nukta.sat;
-pos = (639,-150);
 },
 {
 name = top;
@@ -251,10 +243,6 @@ name = nukta;
 pos = (318,-79);
 },
 {
-name = nukta.sat;
-pos = (748,-157);
-},
-{
 name = top;
 pos = (661,622);
 }
@@ -365,10 +353,6 @@ pos = (420,622);
 {
 name = nukta;
 pos = (192,-29);
-},
-{
-name = nukta.sat;
-pos = (419,-156);
 },
 {
 name = top;
@@ -483,10 +467,6 @@ name = nukta;
 pos = (211,-39);
 },
 {
-name = nukta.sat;
-pos = (477,-127);
-},
-{
 name = top;
 pos = (440,622);
 }
@@ -597,10 +577,6 @@ pos = (575,622);
 {
 name = nukta;
 pos = (249,-77);
-},
-{
-name = nukta.sat;
-pos = (580,-148);
 },
 {
 name = top;

--- a/sources/NotoSansDevanagari.glyphspackage/glyphs/aaM_atra-deva.glyph
+++ b/sources/NotoSansDevanagari.glyphspackage/glyphs/aaM_atra-deva.glyph
@@ -19,7 +19,7 @@ name = halant;
 pos = (99,-20);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (112,-135);
 }
 );
@@ -56,7 +56,7 @@ name = halant;
 pos = (89,-20);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (129,-150);
 }
 );
@@ -93,7 +93,7 @@ name = halant;
 pos = (70,-20);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (158,-157);
 }
 );
@@ -130,7 +130,7 @@ name = halant;
 pos = (76,-20);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (89,-156);
 }
 );
@@ -167,7 +167,7 @@ name = halant;
 pos = (64,-20);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (101,-127);
 }
 );
@@ -204,7 +204,7 @@ name = halant;
 pos = (54,-20);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (130,-148);
 }
 );

--- a/sources/NotoSansDevanagari.glyphspackage/glyphs/au-deva.glyph
+++ b/sources/NotoSansDevanagari.glyphspackage/glyphs/au-deva.glyph
@@ -15,6 +15,10 @@ name = nukta;
 pos = (254,-31);
 },
 {
+name = nukta.sat;
+pos = (782,-135);
+},
+{
 name = top;
 pos = (840,622);
 }
@@ -40,6 +44,10 @@ pos = (853,-40);
 {
 name = nukta;
 pos = (282,-40);
+},
+{
+name = nukta.sat;
+pos = (893,-150);
 },
 {
 name = top;
@@ -69,6 +77,10 @@ name = nukta;
 pos = (318,-79);
 },
 {
+name = nukta.sat;
+pos = (1066,-157);
+},
+{
 name = top;
 pos = (1110,622);
 }
@@ -94,6 +106,10 @@ pos = (574,-40);
 {
 name = nukta;
 pos = (192,-29);
+},
+{
+name = nukta.sat;
+pos = (587,-156);
 },
 {
 name = top;
@@ -123,6 +139,10 @@ name = nukta;
 pos = (211,-39);
 },
 {
+name = nukta.sat;
+pos = (674,-127);
+},
+{
 name = top;
 pos = (718,622);
 }
@@ -148,6 +168,10 @@ pos = (748,-40);
 {
 name = nukta;
 pos = (249,-77);
+},
+{
+name = nukta.sat;
+pos = (823,-148);
 },
 {
 name = top;

--- a/sources/NotoSansDevanagari.glyphspackage/glyphs/auM_atra-deva.glyph
+++ b/sources/NotoSansDevanagari.glyphspackage/glyphs/auM_atra-deva.glyph
@@ -18,7 +18,7 @@ name = halant;
 pos = (99,-20);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (112,-135);
 },
 {
@@ -53,7 +53,7 @@ name = halant;
 pos = (89,-20);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (129,-150);
 },
 {
@@ -88,7 +88,7 @@ name = halant;
 pos = (70,-20);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (158,-157);
 },
 {
@@ -123,7 +123,7 @@ name = halant;
 pos = (76,-20);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (89,-156);
 },
 {
@@ -158,7 +158,7 @@ name = halant;
 pos = (64,-20);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (101,-127);
 },
 {
@@ -193,7 +193,7 @@ name = halant;
 pos = (54,-20);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (130,-148);
 },
 {

--- a/sources/NotoSansDevanagari.glyphspackage/glyphs/o-deva.glyph
+++ b/sources/NotoSansDevanagari.glyphspackage/glyphs/o-deva.glyph
@@ -15,6 +15,10 @@ name = nukta;
 pos = (254,-31);
 },
 {
+name = nukta.sat;
+pos = (782,-135);
+},
+{
 name = top;
 pos = (859,622);
 }
@@ -40,6 +44,10 @@ pos = (853,-40);
 {
 name = nukta;
 pos = (282,-40);
+},
+{
+name = nukta.sat;
+pos = (893,-150);
 },
 {
 name = top;
@@ -69,6 +77,10 @@ name = nukta;
 pos = (318,-79);
 },
 {
+name = nukta.sat;
+pos = (1066,-157);
+},
+{
 name = top;
 pos = (1117,622);
 }
@@ -94,6 +106,10 @@ pos = (574,-40);
 {
 name = nukta;
 pos = (192,-29);
+},
+{
+name = nukta.sat;
+pos = (587,-156);
 },
 {
 name = top;
@@ -123,6 +139,10 @@ name = nukta;
 pos = (211,-39);
 },
 {
+name = nukta.sat;
+pos = (674,-127);
+},
+{
 name = top;
 pos = (721,622);
 }
@@ -148,6 +168,10 @@ pos = (748,-40);
 {
 name = nukta;
 pos = (249,-77);
+},
+{
+name = nukta.sat;
+pos = (823,-148);
 },
 {
 name = top;

--- a/sources/NotoSansDevanagari.glyphspackage/glyphs/oM_atra-deva.glyph
+++ b/sources/NotoSansDevanagari.glyphspackage/glyphs/oM_atra-deva.glyph
@@ -18,7 +18,7 @@ name = halant;
 pos = (99,-20);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (112,-135);
 },
 {
@@ -53,7 +53,7 @@ name = halant;
 pos = (89,-20);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (129,-150);
 },
 {
@@ -88,7 +88,7 @@ name = halant;
 pos = (70,-20);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (158,-157);
 },
 {
@@ -123,7 +123,7 @@ name = halant;
 pos = (76,-20);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (89,-156);
 },
 {
@@ -158,7 +158,7 @@ name = halant;
 pos = (64,-20);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (101,-127);
 },
 {
@@ -193,7 +193,7 @@ name = halant;
 pos = (54,-20);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (130,-148);
 },
 {

--- a/sources/NotoSerifDevanagari.glyphspackage/fontinfo.plist
+++ b/sources/NotoSerifDevanagari.glyphspackage/fontinfo.plist
@@ -5647,7 +5647,7 @@ language SAN ;
 	lookup blwf_rakar_forms_SAN;
 
 language SAT;
-    sub [a-deva aa-deva] nukta-deva' by nukta-deva.sat;
+	sub [aa-deva o-deva au-deva aaMatra-deva oMatra-deva auMatra-deva] nukta-deva' by nukta-deva.sat;
 
 #//////////////////////////////////////////////////////////////////////////////////
 ";

--- a/sources/NotoSerifDevanagari.glyphspackage/glyphs/aaM_atra-deva.glyph
+++ b/sources/NotoSerifDevanagari.glyphspackage/glyphs/aaM_atra-deva.glyph
@@ -19,7 +19,7 @@ name = candra;
 pos = (15,623);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (116,-134);
 },
 {
@@ -50,7 +50,7 @@ name = candra;
 pos = (-11,622);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (116,-89);
 },
 {
@@ -81,7 +81,7 @@ name = candra;
 pos = (79,627);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (116,-172);
 },
 {
@@ -112,7 +112,7 @@ name = candra;
 pos = (-10,622);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (85,-98);
 },
 {
@@ -143,7 +143,7 @@ name = candra;
 pos = (29,623);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (93,-153);
 },
 {
@@ -174,7 +174,7 @@ name = candra;
 pos = (88,627);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (105,-108);
 },
 {

--- a/sources/NotoSerifDevanagari.glyphspackage/glyphs/au-deva.glyph
+++ b/sources/NotoSerifDevanagari.glyphspackage/glyphs/au-deva.glyph
@@ -15,6 +15,10 @@ name = nukta;
 pos = (242,-34);
 },
 {
+name = nukta.sat;
+pos = (802,-141);
+},
+{
 name = top;
 pos = (932,623);
 }
@@ -40,6 +44,10 @@ pos = (637,-5);
 {
 name = nukta;
 pos = (247,-34);
+},
+{
+name = nukta.sat;
+pos = (783,-122);
 },
 {
 name = top;
@@ -69,6 +77,10 @@ name = nukta;
 pos = (273,-50);
 },
 {
+name = nukta.sat;
+pos = (885,-139);
+},
+{
 name = top;
 pos = (1136,623);
 }
@@ -94,6 +106,10 @@ pos = (486,-5);
 {
 name = nukta;
 pos = (193,-34);
+},
+{
+name = nukta.sat;
+pos = (605,-98);
 },
 {
 name = top;
@@ -123,6 +139,10 @@ name = nukta;
 pos = (198,-34);
 },
 {
+name = nukta.sat;
+pos = (639,-132);
+},
+{
 name = top;
 pos = (759,623);
 }
@@ -148,6 +168,10 @@ pos = (588,-9);
 {
 name = nukta;
 pos = (209,-41);
+},
+{
+name = nukta.sat;
+pos = (725,-108);
 },
 {
 name = top;

--- a/sources/NotoSerifDevanagari.glyphspackage/glyphs/auM_atra-deva.glyph
+++ b/sources/NotoSerifDevanagari.glyphspackage/glyphs/auM_atra-deva.glyph
@@ -14,7 +14,7 @@ name = bottom_right;
 pos = (-30,-6);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (121,-125);
 },
 {
@@ -45,7 +45,7 @@ name = bottom_right;
 pos = (-30,-5);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (121,-125);
 },
 {
@@ -76,7 +76,7 @@ name = bottom_right;
 pos = (-32,-10);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (121,-145);
 },
 {
@@ -107,7 +107,7 @@ name = bottom_right;
 pos = (-34,-5);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (84,-125);
 },
 {
@@ -138,7 +138,7 @@ name = bottom_right;
 pos = (-32,-6);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (91,-145);
 },
 {
@@ -169,7 +169,7 @@ name = bottom_right;
 pos = (-32,-9);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (111,-165);
 },
 {

--- a/sources/NotoSerifDevanagari.glyphspackage/glyphs/o-deva.glyph
+++ b/sources/NotoSerifDevanagari.glyphspackage/glyphs/o-deva.glyph
@@ -15,6 +15,10 @@ name = nukta;
 pos = (242,-34);
 },
 {
+name = nukta.sat;
+pos = (802,-141);
+},
+{
 name = top;
 pos = (925,623);
 }
@@ -40,6 +44,10 @@ pos = (637,-5);
 {
 name = nukta;
 pos = (247,-34);
+},
+{
+name = nukta.sat;
+pos = (783,-122);
 },
 {
 name = top;
@@ -69,6 +77,10 @@ name = nukta;
 pos = (273,-50);
 },
 {
+name = nukta.sat;
+pos = (885,-139);
+},
+{
 name = top;
 pos = (1117,623);
 }
@@ -94,6 +106,10 @@ pos = (486,-5);
 {
 name = nukta;
 pos = (193,-34);
+},
+{
+name = nukta.sat;
+pos = (605,-98);
 },
 {
 name = top;
@@ -123,6 +139,10 @@ name = nukta;
 pos = (198,-34);
 },
 {
+name = nukta.sat;
+pos = (639,-132);
+},
+{
 name = top;
 pos = (756,623);
 }
@@ -148,6 +168,10 @@ pos = (588,-9);
 {
 name = nukta;
 pos = (209,-41);
+},
+{
+name = nukta.sat;
+pos = (725,-108);
 },
 {
 name = top;

--- a/sources/NotoSerifDevanagari.glyphspackage/glyphs/oM_atra-deva.glyph
+++ b/sources/NotoSerifDevanagari.glyphspackage/glyphs/oM_atra-deva.glyph
@@ -14,7 +14,7 @@ name = bottom_right;
 pos = (-30,-6);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (121,-125);
 },
 {
@@ -45,7 +45,7 @@ name = bottom_right;
 pos = (-30,-5);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (121,-125);
 },
 {
@@ -76,7 +76,7 @@ name = bottom_right;
 pos = (-32,-10);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (121,-145);
 },
 {
@@ -107,7 +107,7 @@ name = bottom_right;
 pos = (-34,-5);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (84,-125);
 },
 {
@@ -138,7 +138,7 @@ name = bottom_right;
 pos = (-32,-6);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (91,-145);
 },
 {
@@ -169,7 +169,7 @@ name = bottom_right;
 pos = (-32,-9);
 },
 {
-name = nukta;
+name = nukta.sat;
 pos = (111,-165);
 },
 {


### PR DESCRIPTION
Hello. Thank you for providing us with great fonts.
I’d like to submit a pull request for Santali language support.

The target is the following two issues.
https://github.com/notofonts/devanagari/issues/42
https://github.com/notofonts/devanagari/issues/43

**Sample**
आ़: U+0906(आ), U+093C(़)
ओ़: U+0913(ओ), U+093C(़)
औ़: U+0914(औ), U+093C(़)
आ़ँ: U+0906(आ), U+093C(़), U+0901(ँ)
ओ़ँ: U+0913(ओ), U+093C(़), U+0901(ँ)
औ़ँ: U+0914(औ), U+093C(़), U+0901(ँ)
आ़ं: U+0906(आ), U+093C(़), U+0902(ं)
ओ़ं: U+0913(ओ), U+093C(़), U+0902(ं)
औ़ं: U+0914(औ), U+093C(़), U+0902(ं)

ा़: U+093E(ा), U+093C(़)
ो़: U+094B(ो), U+093C(़)
ौ़: U+094C(ौ), U+093C(़)
ा़ँ: U+093E(ा), U+093C(़), U+0901(ँ)
ो़ँ: U+094B(ो), U+093C(़), U+0901(ँ)
ौ़ँ: U+094C(ौ), U+093C(़), U+0901(ँ)
ा़ं: U+093E(ा), U+093C(़), U+0902(ं)
ो़ं: U+094B(ो), U+093C(़), U+0902(ं)
ौ़ं: U+094C(ौ), U+093C(़), U+0902(ं)

Noto Sans Devanagari (language: Santali)
![image](https://github.com/user-attachments/assets/8be30dd6-b1a7-4dbd-954a-f6e8d97beb6b)

Noto Sans Devanagari (language: default)
![image](https://github.com/user-attachments/assets/79b70e8d-9dbd-4443-be1c-7fea9effa260)

Noto Serif Devanagari (language: Santali)
![image](https://github.com/user-attachments/assets/7576cc4e-7b25-43d3-90a6-37445d4dd979)

Noto Serif Devanagari (language: default)
![image](https://github.com/user-attachments/assets/c931c934-41f0-49e8-bbe5-132635dd66b5)

Thank you for taking this request into consideration.
