### PR TITLE
Fix NEP rendering for Reph conjuncts and ईँ ligature

### DIFF
--- a/sources/NotoSansDevanagari.glyphspackage/fontinfo.plist
+++ b/sources/NotoSansDevanagari.glyphspackage/fontinfo.plist
@@ -5052,7 +5052,9 @@ language dflt ;
 		sub halant-deva ra-deva by rakar-deva;
 	} belowBase_forms_dev2;
 
-language MAR ;
+language NEP;
+lookup belowBase_forms_dev2 ;
+language MAR;
 lookup belowBase_forms_dev2 ;
 
 #//////////////////////////////////////////////////////////////////////////////////

--- a/sources/NotoSansDevanagari.glyphspackage/fontinfo.plist
+++ b/sources/NotoSansDevanagari.glyphspackage/fontinfo.plist
@@ -5616,6 +5616,11 @@ lookup decompose_long_vowels {
 	sub ai-deva by e-deva eMatra-deva;
 } decompose_long_vowels;
 
+lookup reph_ligature_after_decomposed_ii {
+	sub i-deva reph-deva' lookup reph_ligature anusvara-deva';
+	sub i-deva reph-deva' lookup reph_ligature candraBindu-deva';
+} reph_ligature_after_decomposed_ii;
+
 lookup abvs_01 {
 
 	sub ayMatra-deva anusvara-deva by ayMatra_anusvara-deva;


### PR DESCRIPTION
This pull request addresses two rendering issues in Noto Sans Devanagari:

1. [Rakar conjuncts (ट्र, ठ्र, ड्र, etc.) render incorrectly with NEP language tag](https://github.com/notofonts/devanagari/issues/59)
Applies the same substitution logic used for MAR to NEP, ensuring correct rendering of conjuncts like ट्र, ठ्र, ड्र, etc.

**Before (v2.006, Default Hindi)**
![image](https://github.com/user-attachments/assets/07635593-ea65-4798-835c-3e17cea3ab90)
**Before (v2.006, Marathi)**
![image](https://github.com/user-attachments/assets/622f40ff-e9d6-4c17-8d7f-d8beb42d3ea4)
**Before (v2.006, Nepali)**
![image](https://github.com/user-attachments/assets/17e96931-e173-477a-b76b-ffb4e57bc066)
**After (this PR,  Nepali)**
![image](https://github.com/user-attachments/assets/357eb3ae-b796-484c-9e41-dd14251d420b)

2. [Ligature for ईँ (ii-deva + candrabindu) not formed correctly](https://github.com/notofonts/devanagari/issues/60)
Adds a ligature substitution for reph-deva + candrabindu-deva in the ‘abvs’ feature to ensure correct rendering of ईँ after decomposition.

**Before (v2.006)**
![image](https://github.com/user-attachments/assets/66f96e94-605b-45a3-8d69-aab80c43ff6b)
**After (this PR)**
![image](https://github.com/user-attachments/assets/6e256f6d-9448-4ee5-ab75-f935d74812bf)
These changes improve rendering accuracy for Nepali users, especially in environments like Microsoft Word where language tagging affects shaping behavior.