### PR TITLE
Fix rendering of ईँ and ईं in Noto Serif Devanagari

### DIFF
--- a/sources/NotoSerifDevanagari.glyphspackage/fontinfo.plist
+++ b/sources/NotoSerifDevanagari.glyphspackage/fontinfo.plist
@@ -6351,6 +6351,10 @@ lookup decompose_long_vowels {
 } decompose_long_vowels;
 
 
+lookup reph_ligature_after_decomposed_ii {
+	sub i-deva reph-deva' lookup reph_ligature anusvara-deva';
+	sub i-deva reph-deva' lookup reph_ligature candraBindu-deva';
+} reph_ligature_after_decomposed_ii;
 
 #----------------------------------------------------------------------------------
 # 		Lookups for Composite Above-base Marks


### PR DESCRIPTION
Equivalent fix to the Noto Serif Devanagari as in the commit <a href = "https://github.com/notofonts/devanagari/pull/61/commits/5bda8a59d75da3bbf72736fffb5d07a6849be97a">5bda8a</a> of pull #61, .

Mentioned commit had fixed the rendering only for Noto Sans Devanagari.

This commit would fix the issue #58 and #53.

Thank you